### PR TITLE
Update to Tasmota v5.12.0k - Fix two define changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Sonoff-Tasmota
 Provide ESP8266 based Sonoff by [iTead Studio](https://www.itead.cc/) and ElectroDragon IoT Relay with Serial, Web and MQTT control allowing 'Over the Air' or OTA firmware updates using Arduino IDE.
 
-Current version is **5.12.0j** - See [sonoff/_releasenotes.ino](https://github.com/arendst/Sonoff-Tasmota/blob/development/sonoff/_releasenotes.ino) for change information.
+Current version is **5.12.0k** - See [sonoff/_releasenotes.ino](https://github.com/arendst/Sonoff-Tasmota/blob/development/sonoff/_releasenotes.ino) for change information.
 
 ### Quick install
 

--- a/sonoff/_releasenotes.ino
+++ b/sonoff/_releasenotes.ino
@@ -1,4 +1,9 @@
-/* 5.12.0j
+/* 5.12.0k
+ * Prepare for simple rules by enlarging Settings area to now 2048 bytes
+ * Fix freeing more code space when emulation is disabled (#1592)
+ * Fix compile error when not defined USE_TIMERS (#2400)
+ *
+ * 5.12.0j
  * Add optional Sunrise and Sunset timers with commands Latitide and Longitude to be enabled with define USE_SUNRISE in user_config.h (#2317)
  *
  * 5.12.0i

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -48,7 +48,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t not_power_linked : 1;         // bit 20 (v5.11.1f)
     uint32_t no_power_on_check : 1;        // bit 21 (v5.11.1i)
     uint32_t mqtt_serial : 1;              // bit 22 (v5.12.0f)
-    uint32_t spare23 : 1;
+    uint32_t rules_enabled : 1;            // bit 23 (v5.12.0j)
     uint32_t spare24 : 1;
     uint32_t spare25 : 1;
     uint32_t spare26 : 1;
@@ -255,7 +255,12 @@ struct SYSCFG {
   Timer         timer[MAX_TIMERS];         // 670
   int           latitude;                  // 6B0
   int           longitude;                 // 6B4
-                                           // 6B8 - FFF free locations
+
+  byte          free_6b8[72];              // 6B8
+
+  char          rules[256];                // 700
+
+                                           // 800 - FFF free locations
 } Settings;
 
 struct RTCMEM {

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -927,6 +927,10 @@ void SettingsDelta()
       Settings.latitude = (int)((double)LATITUDE * 1000000);
       Settings.longitude = (int)((double)LONGITUDE * 1000000);
     }
+    if (Settings.version < 0x050C000B) {
+      memset(&Settings.free_6b8, 0x00, sizeof(Settings.free_6b8));
+      memset(&Settings.rules, 0x00, sizeof(Settings.rules));
+    }
 
     Settings.version = VERSION;
     SettingsSave(1);

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -25,7 +25,7 @@
     - Select IDE Tools - Flash Size: "1M (no SPIFFS)"
   ====================================================*/
 
-#define VERSION                0x050C000A   // 5.12.0j
+#define VERSION                0x050C000B   // 5.12.0k
 
 // Location specific includes
 #include <core_version.h>                   // Arduino_Esp8266 version information (ARDUINO_ESP8266_RELEASE and ARDUINO_ESP8266_RELEASE_2_3_0)
@@ -558,7 +558,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
       XsnsCall(FUNC_COMMAND);
 //      if (!XsnsCall(FUNC_COMMAND)) type = NULL;
     }
-    else if ((CMND_SETOPTION == command_code) && ((index <= 21) || ((index > 31) && (index <= P_MAX_PARAM8 + 31)))) {
+    else if ((CMND_SETOPTION == command_code) && ((index <= 23) || ((index > 31) && (index <= P_MAX_PARAM8 + 31)))) {
       if (index <= 31) {
         ptype = 0;   // SetOption0 .. 31
       } else {
@@ -588,6 +588,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
               case 19:  // hass_discovery
               case 20:  // not_power_linked
               case 21:  // no_power_on_check
+              case 23:  // rules_enabled
                 bitWrite(Settings.flag.data, index, payload);
             }
             if (12 == index) {  // stop_flash_rotate
@@ -1305,13 +1306,13 @@ void PublishStatus(uint8_t payload)
   }
 
   if ((0 == payload) || (7 == payload)) {
-#ifdef USE_SUNRISE
+#if defined(USE_TIMERS) && defined(USE_SUNRISE)
     snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_CMND_STATUS D_STATUS7_TIME "\":{\"" D_JSON_UTC_TIME "\":\"%s\",\"" D_JSON_LOCAL_TIME "\":\"%s\",\"" D_JSON_STARTDST "\":\"%s\",\"" D_JSON_ENDDST "\":\"%s\",\"" D_CMND_TIMEZONE "\":%d,\"" D_JSON_SUNRISE "\":\"%s\",\"" D_JSON_SUNSET "\":\"%s\"}}"),
       GetTime(0).c_str(), GetTime(1).c_str(), GetTime(2).c_str(), GetTime(3).c_str(), Settings.timezone, GetSun(0).c_str(), GetSun(1).c_str());
 #else
     snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_CMND_STATUS D_STATUS7_TIME "\":{\"" D_JSON_UTC_TIME "\":\"%s\",\"" D_JSON_LOCAL_TIME "\":\"%s\",\"" D_JSON_STARTDST "\":\"%s\",\"" D_JSON_ENDDST "\":\"%s\",\"" D_CMND_TIMEZONE "\":%d}}"),
       GetTime(0).c_str(), GetTime(1).c_str(), GetTime(2).c_str(), GetTime(3).c_str(), Settings.timezone);
-#endif  // USE_SUNRISE
+#endif  // USE_TIMERS and USE_SUNRISE
     MqttPublishPrefixTopic_P(option, PSTR(D_CMND_STATUS "7"));
   }
 
@@ -2423,11 +2424,10 @@ void loop()
 
 #ifdef USE_WEBSERVER
   PollDnsWebserver();
-#endif  // USE_WEBSERVER
-
 #ifdef USE_EMULATION
   if (Settings.flag2.emulation) PollUdp();
 #endif  // USE_EMULATION
+#endif  // USE_WEBSERVER
 
   if (millis() >= state_loop_timer) StateLoop();
 

--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -617,7 +617,7 @@ void WifiConfig(uint8_t type)
     if (type >= WIFI_RETRY) {  // WIFI_RETRY and WIFI_WAIT
       return;
     }
-#ifdef USE_EMULATION
+#if defined(USE_WEBSERVER) && defined(USE_EMULATION)
     UdpDisconnect();
 #endif  // USE_EMULATION
     WiFi.disconnect();        // Solve possible Wifi hangs
@@ -653,7 +653,7 @@ void WifiBegin(uint8_t flag)
 {
   const char kWifiPhyMode[] = " BGN";
 
-#ifdef USE_EMULATION
+#if defined(USE_WEBSERVER) && defined(USE_EMULATION)
   UdpDisconnect();
 #endif  // USE_EMULATION
 
@@ -840,7 +840,7 @@ void WifiCheck(uint8_t param)
 #endif  // USE_EMULATION
 #endif  // USE_WEBSERVER
       } else {
-#ifdef USE_EMULATION
+#if defined(USE_WEBSERVER) && defined(USE_EMULATION)
         UdpDisconnect();
 #endif  // USE_EMULATION
         mdns_begun = false;

--- a/sonoff/xdrv_00_mqtt.ino
+++ b/sonoff/xdrv_00_mqtt.ino
@@ -418,7 +418,7 @@ void MqttReconnect()
     return;
   }
 
-#ifdef USE_EMULATION
+#if defined(USE_WEBSERVER) && defined(USE_EMULATION)
   UdpDisconnect();
 #endif  // USE_EMULATION
 

--- a/sonoff/xplg_wemohue.ino
+++ b/sonoff/xplg_wemohue.ino
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef USE_EMULATION
+#if defined(USE_WEBSERVER) && defined(USE_EMULATION)
 /*********************************************************************************************\
  * Belkin WeMo and Philips Hue bridge emulation
 \*********************************************************************************************/
@@ -266,7 +266,6 @@ void PollUdp()
   }
 }
 
-#ifdef USE_WEBSERVER
 /*********************************************************************************************\
  * Wemo web server additions
 \*********************************************************************************************/
@@ -814,6 +813,4 @@ void HandleHueApi(String *path)
   else if (path->endsWith("/rules")) HueNotImplemented(path);
   else HueGlobalConfig(path);
 }
-#endif  // USE_WEBSERVER
-#endif  // USE_EMULATION
-
+#endif  // USE_WEBSERVER && USE_EMULATION


### PR DESCRIPTION
Tasmota 5.12.0k
 * Prepare for simple rules by enlarging Settings area to now
2048 bytes
 * Fix freeing more code space when emulation is disabled
(#1592)
 * Fix compile error when not defined USE_TIMERS (#2400)