### PR TITLE
Update from Tasmota

### DIFF
--- a/sonoff/_releasenotes.ino
+++ b/sonoff/_releasenotes.ino
@@ -7,6 +7,8 @@
  * Fix KNX config error (#2628)
  * Fix sensor MHZ-19 vanishing data over time (#2659)
  * Fix KNX reconnection issue (#2679)
+ * Fix DST and STD time for Southern Hemisphere (#2684, #2714)
+ * Add SetOption26 to enforce use of indexes even when only one relay is present (#1055)
  * Add Portuguese in Brazil language file
  * Add rule state test for On/Off in addition to 0/1 (#2613)
  * Add hardware serial option to MHZ-19 sensor (#2659)

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -51,7 +51,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t rules_enabled : 1;            // bit 23 (v5.12.0j)
     uint32_t rules_once : 1;               // bit 24 (v5.12.0k)
     uint32_t knx_enabled : 1;              // bit 25 (v5.12.0l) KNX
-    uint32_t spare26 : 1;
+    uint32_t device_index_enable : 1;      // bit 26 (v5.13.1a)
     uint32_t spare27 : 1;
     uint32_t spare28 : 1;
     uint32_t spare29 : 1;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -376,6 +376,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
   byte jsflg = 0;
   byte lines = 1;
   uint8_t grpflg = 0;
+//  uint8_t user_append_index = 0;
   uint16_t i = 0;
   uint16_t index;
   uint32_t address;
@@ -407,7 +408,10 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
     while (isdigit(type[i-1])) {
       i--;
     }
-    if (i < strlen(type)) index = atoi(type +i);
+    if (i < strlen(type)) {
+      index = atoi(type +i);
+//      user_append_index = 1;
+    }
     type[i] = '\0';
   }
 
@@ -478,6 +482,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
     }
     else if ((CMND_POWER == command_code) && (index > 0) && (index <= devices_present)) {
       if ((payload < 0) || (payload > 4)) payload = 9;
+//      Settings.flag.device_index_enable = user_append_index;
       ExecuteCommandPower(index, payload);
       fallback_topic_flag = 0;
       return;
@@ -553,7 +558,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
       XsnsCall(FUNC_COMMAND);
 //      if (!XsnsCall(FUNC_COMMAND)) type = NULL;
     }
-    else if ((CMND_SETOPTION == command_code) && ((index <= 21) || ((index > 31) && (index <= P_MAX_PARAM8 + 31)))) {
+    else if ((CMND_SETOPTION == command_code) && ((index <= 26) || ((index > 31) && (index <= P_MAX_PARAM8 + 31)))) {
       if (index <= 31) {
         ptype = 0;   // SetOption0 .. 31
       } else {
@@ -585,6 +590,9 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
               case 21:  // no_power_on_check
 //              case 22:  // mqtt_serial - use commands SerialSend and SerialLog
 //              case 23:  // rules_enabled - use command Rule
+//              case 24:  // rules_once
+//              case 25:  // knx_enabled
+              case 26:  // device_index_enable
                 bitWrite(Settings.flag.data, index, payload);
             }
             if (12 == index) {  // stop_flash_rotate
@@ -1367,7 +1375,7 @@ void MqttShowState()
     if (i == light_device -1) {
       LightState(1);
     } else {
-      snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"%s\":\"%s\""), mqtt_data, GetPowerDevice(stemp1, i +1, sizeof(stemp1)), GetStateText(bitRead(power, i)));
+      snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"%s\":\"%s\""), mqtt_data, GetPowerDevice(stemp1, i +1, sizeof(stemp1), Settings.flag.device_index_enable), GetStateText(bitRead(power, i)));
     }
   }
 

--- a/sonoff/xdrv_00_mqtt.ino
+++ b/sonoff/xdrv_00_mqtt.ino
@@ -280,10 +280,9 @@ void MqttPublishPowerState(byte device)
   char stopic[TOPSZ];
   char scommand[33];
 
-  if ((device < 1) || (device > devices_present)) {
-    device = 1;
-  }
-  GetPowerDevice(scommand, device, sizeof(scommand));
+  if ((device < 1) || (device > devices_present)) { device = 1; }
+  GetPowerDevice(scommand, device, sizeof(scommand), Settings.flag.device_index_enable);
+
   GetTopic_P(stopic, STAT, mqtt_topic, (Settings.flag.mqtt_response) ? scommand : S_RSLT_RESULT);
   snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_SVALUE, scommand, GetStateText(bitRead(power, device -1)));
   MqttPublish(stopic);
@@ -301,7 +300,7 @@ void MqttPublishPowerBlinkState(byte device)
     device = 1;
   }
   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"%s\":\"" D_JSON_BLINK " %s\"}"),
-    GetPowerDevice(scommand, device, sizeof(scommand)), GetStateText(bitRead(blink_mask, device -1)));
+    GetPowerDevice(scommand, device, sizeof(scommand), Settings.flag.device_index_enable), GetStateText(bitRead(blink_mask, device -1)));
 
   MqttPublishPrefixTopic_P(RESULT_OR_STAT, S_RSLT_POWER);
 }
@@ -723,7 +722,7 @@ bool MqttCommand()
     if ((payload >= 0) && (payload <= 1)) {
       if (!payload) {
         for(i = 1; i <= devices_present; i++) {  // Clear MQTT retain in broker
-          GetTopic_P(stemp1, STAT, mqtt_topic, GetPowerDevice(scommand, i, sizeof(scommand)));
+          GetTopic_P(stemp1, STAT, mqtt_topic, GetPowerDevice(scommand, i, sizeof(scommand), Settings.flag.device_index_enable));
           mqtt_data[0] = '\0';
           MqttPublish(stemp1, Settings.flag.mqtt_power_retain);
         }
@@ -744,7 +743,7 @@ bool MqttCommand()
     snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_SVALUE, command, GetStateText(Settings.flag.mqtt_sensor_retain));
   }
   else serviced = false;  // Unknown command
-  
+
   return serviced;
 }
 

--- a/sonoff/xdrv_01_light.ino
+++ b/sonoff/xdrv_01_light.ino
@@ -545,7 +545,7 @@ void LightState(uint8_t append)
   } else {
     snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{"));
   }
-  GetPowerDevice(scommand, light_device, sizeof(scommand));
+  GetPowerDevice(scommand, light_device, sizeof(scommand), Settings.flag.device_index_enable);
   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s\"%s\":\"%s\",\"" D_CMND_DIMMER "\":%d"),
     mqtt_data, scommand, GetStateText(light_power), Settings.light_dimmer);
   if (light_subtype > LST_SINGLE) {

--- a/sonoff/xdrv_07_home_assistant.ino
+++ b/sonoff/xdrv_07_home_assistant.ino
@@ -96,7 +96,7 @@ void HAssDiscoverRelay()
       } else {
         snprintf_P(name, sizeof(name), Settings.friendlyname[i -1]);
       }
-      GetPowerDevice(value_template, i, sizeof(value_template));
+      GetPowerDevice(value_template, i, sizeof(value_template), Settings.flag.device_index_enable);
       GetTopic_P(command_topic, CMND, mqtt_topic, value_template);
       GetTopic_P(state_topic, STAT, mqtt_topic, S_RSLT_RESULT);
       GetTopic_P(availability_topic, TELE, mqtt_topic, S_LWT);
@@ -171,7 +171,7 @@ void HAssDiscoverButton()
         } else {
           snprintf_P(name, sizeof(name), PSTR("%s BTN"), Settings.friendlyname[button_index]);
         }
-        GetPowerDevice(value_template, button_index+1, sizeof(value_template));
+        GetPowerDevice(value_template, button_index+1, sizeof(value_template), Settings.flag.device_index_enable);
         GetTopic_P(state_topic, CMND, key_topic, value_template); // State of button is sent as CMND TOGGLE
         GetTopic_P(availability_topic, TELE, mqtt_topic, S_LWT);
         snprintf_P(mqtt_data, sizeof(mqtt_data), HASS_DISCOVER_BUTTON, name, state_topic, Settings.state_text[2], availability_topic);

--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -248,6 +248,9 @@ bool RulesProcess()
 
   delay(0);                                               // Prohibit possible loop software watchdog
 
+//snprintf_P(log_data, sizeof(log_data), PSTR("RUL: Event = %s, Rule = %s"), mqtt_data, Settings.rules);
+//AddLog(LOG_LEVEL_DEBUG);
+
   if (!Settings.flag.rules_enabled) { return serviced; }  // Not enabled
   if (!strlen(Settings.rules)) { return serviced; }       // No rules
 
@@ -274,12 +277,12 @@ bool RulesProcess()
     if (plen == -1) { return serviced; }                  // Bad syntax - No endon
     String commands = rules.substring(pevt +4, plen);     // "Backlog Dimmer 10;Color 100000"
     plen += 6;
-
-//snprintf_P(log_data, sizeof(log_data), PSTR("RUL: Trigger |%s|, Commands |%s|"), event_trigger.c_str(), commands.c_str());
-//AddLog(LOG_LEVEL_DEBUG);
-
     rules_event_value = "";
     String event = event_saved;
+
+//snprintf_P(log_data, sizeof(log_data), PSTR("RUL: Event |%s|, Rule |%s|, Command(s) |%s|"), event.c_str(), event_trigger.c_str(), commands.c_str());
+//AddLog(LOG_LEVEL_DEBUG);
+
     if (RulesRuleMatch(event, event_trigger)) {
       commands.trim();
       String ucommand = commands;

--- a/sonoff/xsns_24_si1145.ino
+++ b/sonoff/xsns_24_si1145.ino
@@ -210,6 +210,11 @@ uint8_t Si1145WriteParamData(uint8_t p, uint8_t v)
 
 /********************************************************************************************/
 
+bool Si1145Present()
+{
+  return (Si1145ReadByte(SI114X_PART_ID) == 0X45);
+}
+
 void Si1145Reset()
 {
   Si1145WriteByte(SI114X_MEAS_RATE0, 0);
@@ -234,19 +239,19 @@ void Si1145DeInit()
   Si1145WriteByte(SI114X_UCOEFF1, 0x89);
   Si1145WriteByte(SI114X_UCOEFF2, 0x02);
   Si1145WriteByte(SI114X_UCOEFF3, 0x00);
-  Si1145WriteParamData(SI114X_CHLIST, SI114X_CHLIST_ENUV |SI114X_CHLIST_ENALSIR | SI114X_CHLIST_ENALSVIS |SI114X_CHLIST_ENPS1);
+  Si1145WriteParamData(SI114X_CHLIST, SI114X_CHLIST_ENUV | SI114X_CHLIST_ENALSIR | SI114X_CHLIST_ENALSVIS | SI114X_CHLIST_ENPS1);
   //
   //set LED1 CURRENT(22.4mA)(It is a normal value for many LED)
   //
   Si1145WriteParamData(SI114X_PS1_ADCMUX, SI114X_ADCMUX_LARGE_IR);
   Si1145WriteByte(SI114X_PS_LED21, SI114X_LED_CURRENT_22MA);
-  Si1145WriteParamData(SI114X_PSLED12_SELECT, SI114X_PSLED12_SELECT_PS1_LED1); //
+  Si1145WriteParamData(SI114X_PSLED12_SELECT, SI114X_PSLED12_SELECT_PS1_LED1);
   //
   //PS ADC SETTING
   //
   Si1145WriteParamData(SI114X_PS_ADC_GAIN, SI114X_ADC_GAIN_DIV1);
   Si1145WriteParamData(SI114X_PS_ADC_COUNTER, SI114X_ADC_COUNTER_511ADCCLK);
-  Si1145WriteParamData(SI114X_PS_ADC_MISC, SI114X_ADC_MISC_HIGHRANGE|SI114X_ADC_MISC_ADC_RAWADC);
+  Si1145WriteParamData(SI114X_PS_ADC_MISC, SI114X_ADC_MISC_HIGHRANGE | SI114X_ADC_MISC_ADC_RAWADC);
   //
   //VIS ADC SETTING
   //
@@ -273,7 +278,7 @@ void Si1145DeInit()
 
 boolean Si1145Begin()
 {
-  if (Si1145ReadByte(SI114X_PART_ID) != 0X45) { return false; }
+  if (!Si1145Present()) { return false; }
 
   Si1145Reset();
   Si1145DeInit();
@@ -320,7 +325,7 @@ const char HTTP_SNS_SI1145[] PROGMEM = "%s"
 
 void Si1145Show(boolean json)
 {
-  if (si1145_type) {
+  if (si1145_type && Si1145Present()) {
     uint16_t visible = Si1145ReadVisible();
     uint16_t infrared = Si1145ReadIR();
     uint16_t uvindex = Si1145ReadUV();
@@ -335,6 +340,8 @@ void Si1145Show(boolean json)
       snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_SI1145, mqtt_data, visible, infrared, uvindex /100, uvindex %100);
 #endif
     }
+  } else {
+    si1145_type = 0;
   }
 }
 


### PR DESCRIPTION
5.13.1a
* Add SetOption26 to enforce use of indexes even when only one relay is
present (#1055)